### PR TITLE
Unit tests for socket connection

### DIFF
--- a/remote_robot_web/control_board/socket_connection.py
+++ b/remote_robot_web/control_board/socket_connection.py
@@ -27,7 +27,6 @@ class RobotCommand:
 class SocketConnection(Thread):
     """Thread managing the local connection (with sockets) with ROS to send commands and receive video"""
 
-    #frame = np.random.randint(0,255,(480,640,3))
     frame = np.zeros((480, 640, 3)) # Static variable containing the currently received frame
     command = None # Static variable containing the currently sent command
 
@@ -107,6 +106,4 @@ class SocketConnection(Thread):
     @staticmethod
     def send_command(robot_id,command_id):
         """Tells the thread to send a command by switching the static variable command"""
-        print(SocketConnection.command)
         SocketConnection.command = RobotCommand(robot_id,command_id)
-        print(SocketConnection.command)

--- a/remote_robot_web/control_board/socket_connection.py
+++ b/remote_robot_web/control_board/socket_connection.py
@@ -35,20 +35,25 @@ class SocketConnection(Thread):
         Thread.__init__(self)
         self.__connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.__registered_robots = dict() #Dict containing the info of each registered robots (key = id, value = [height,width])
+        self.is_running = True
 
     def run(self):
         self.__start_connection()
-        while True :
-            #Listen to receive messages
-            self.__listen()
-
-            #Write messages if a command needs to be sent
+        while self.is_running :
+            # Write messages if a command needs to be sent
             if SocketConnection.command is not None:
                 print(SocketConnection.command.get_string_command())
                 self.__client_connection.sendall(SocketConnection.command.get_bytes_command())
                 SocketConnection.command = None
 
+            #Listen to receive messages
+            self.__listen()
+
             sleep(0.001)
+
+    def stop(self):
+        self.is_running = False
+        self.__stop_connection()
 
 
 
@@ -59,7 +64,6 @@ class SocketConnection(Thread):
         port = 12800
 
         self.__connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        #self.__connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.__connection.bind((host, port))
         self.__connection.listen(5)
         self.__client_connection, info = self.__connection.accept()
@@ -103,4 +107,6 @@ class SocketConnection(Thread):
     @staticmethod
     def send_command(robot_id,command_id):
         """Tells the thread to send a command by switching the static variable command"""
+        print(SocketConnection.command)
         SocketConnection.command = RobotCommand(robot_id,command_id)
+        print(SocketConnection.command)

--- a/remote_robot_web/control_board/test_socket_connection.py
+++ b/remote_robot_web/control_board/test_socket_connection.py
@@ -9,19 +9,19 @@ class TestSocketConnection(unittest.TestCase):
     """TestCase to test the SocketConnection class"""
 
     def setUp(self):
-        pass
-
-    def connect_to_ros(self):
         self.socket_thread = SocketConnection()  # Creates the socket thread to connect in localhost with ROS
         self.ros_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    def connect_to_ros(self):
         if not self.socket_thread.is_alive():
             self.socket_thread.start()
         self.ros_connection.connect(('localhost', 12800))
         self.ros_connection.send(b'\x19')
 
     def disconnect_from_ros(self):
-        self.socket_thread.stop()
         self.ros_connection.close()
+        self.socket_thread.stop()
+
 
     def test_connection_established(self):
         """The socket can connect"""

--- a/remote_robot_web/control_board/test_socket_connection.py
+++ b/remote_robot_web/control_board/test_socket_connection.py
@@ -1,0 +1,53 @@
+import unittest
+
+import socket
+
+
+from socket_connection import SocketConnection
+
+class TestSocketConnection(unittest.TestCase):
+    """TestCase to test the SocketConnection class"""
+
+    def setUp(self):
+        pass
+
+    def connect_to_ros(self):
+        self.socket_thread = SocketConnection()  # Creates the socket thread to connect in localhost with ROS
+        self.ros_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if not self.socket_thread.is_alive():
+            self.socket_thread.start()
+        self.ros_connection.connect(('localhost', 12800))
+        self.ros_connection.send(b'\x19')
+
+    def disconnect_from_ros(self):
+        self.socket_thread.stop()
+        self.ros_connection.close()
+
+    def test_connection_established(self):
+        """The socket can connect"""
+        self.connect_to_ros()
+        msg = self.ros_connection.recv(1)
+        self.assertEqual(msg,b'\x19')
+        self.disconnect_from_ros()
+
+    def test_command_sent_up(self):
+        """The socket can send a up command"""
+        self.connect_to_ros()
+        msg = self.ros_connection.recv(1)
+        SocketConnection.send_command(0,0)
+        msg = self.ros_connection.recv(3)
+        self.assertEqual(msg,b'\x0a' + b'\x00' + b'\x00')
+        self.disconnect_from_ros()
+
+    def test_command_sent_down(self):
+        """The socket can send a down command"""
+        self.connect_to_ros()
+        msg = self.ros_connection.recv(1)
+        SocketConnection.send_command(0,1)
+        msg = self.ros_connection.recv(3)
+        self.assertEqual(msg,b'\x0a' + b'\x00' + b'\x01')
+        self.disconnect_from_ros()
+
+
+
+


### PR DESCRIPTION
To launch tests (only for establishing connection and sending commands)

`cd remote_robot_web/control_board`
`python -m unittest`

There are 3 unit tests.